### PR TITLE
Feature create object store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+.idea

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module GoDB
+
+go 1.16

--- a/internal/pkg/assert/assert.go
+++ b/internal/pkg/assert/assert.go
@@ -1,0 +1,12 @@
+package assert
+
+import (
+	"reflect"
+	"testing"
+)
+
+func ExpectEq(actual interface{}, expected interface{}, t *testing.T) {
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}

--- a/internal/pkg/storage/map.go
+++ b/internal/pkg/storage/map.go
@@ -1,0 +1,33 @@
+package storage
+
+type Map struct {
+	Data map[string]map[string]string
+}
+
+func NewMap() *Map {
+	return &Map{map[string]map[string]string{}}
+}
+
+func (m *Map) Set(key string, field string, value string) int {
+	if m.Data == nil {
+		m.Data = map[string]map[string]string{}
+	}
+	if m.Data[key] == nil {
+		m.Data[key] = map[string]string{}
+	}
+	m.Data[key][field] = value
+	return 1
+}
+
+func (m *Map) Get(key string, field string) (string, bool) {
+	value, ok := m.Data[key][field]
+	return value, ok
+}
+
+func (m *Map) Del(key string, field string) int {
+	if _, ok := m.Data[key][field]; ok {
+		delete(m.Data[key], field)
+		return 1
+	}
+	return 0
+}

--- a/internal/pkg/storage/map_test.go
+++ b/internal/pkg/storage/map_test.go
@@ -1,0 +1,67 @@
+package storage
+
+import (
+	"GoDB/internal/pkg/assert"
+	"testing"
+)
+
+func TestMap_Set(t *testing.T) {
+	m := NewMap()
+	insertedCount := m.Set("key", "field", "value")
+	assert.ExpectEq(insertedCount, 1, t)
+}
+
+func TestMap_Get(t *testing.T) {
+	m := NewMap()
+	_ = m.Set("key", "field", "value")
+	value, ok := m.Get("key", "field")
+	assert.ExpectEq(value, "value", t)
+	assert.ExpectEq(ok, true, t)
+}
+
+func TestMap_GetNonExistentKey(t *testing.T) {
+	m := NewMap()
+	value, ok := m.Get("key", "field")
+	assert.ExpectEq(value, "", t)
+	assert.ExpectEq(ok, false, t)
+}
+
+func TestMap_GetNonExistentField(t *testing.T) {
+	m := NewMap()
+	_ = m.Set("key", "field", "value")
+	value, ok := m.Get("key", "diff")
+	assert.ExpectEq(value, "", t)
+	assert.ExpectEq(ok, false, t)
+}
+
+func TestMap_ReplaceValue(t *testing.T) {
+	m := NewMap()
+	_ = m.Set("key", "field", "value")
+	_ = m.Set("key", "field", "diff")
+	value, ok := m.Get("key", "field")
+	assert.ExpectEq(value, "diff", t)
+	assert.ExpectEq(ok, true, t)
+}
+
+func TestMap_Del(t *testing.T) {
+	m := NewMap()
+	_ = m.Set("key", "field", "value")
+	deletedCount := m.Del("key", "field")
+	value, ok := m.Get("key", "field")
+	assert.ExpectEq(deletedCount, 1, t)
+	assert.ExpectEq(value, "", t)
+	assert.ExpectEq(ok, false, t)
+}
+
+func TestMap_DelNonexistentKey(t *testing.T) {
+	m := NewMap()
+	deletedCount := m.Del("key", "field")
+	assert.ExpectEq(deletedCount, 0, t)
+}
+
+func TestMap_DelNonExistentField(t *testing.T) {
+	m := NewMap()
+	_ = m.Set("key", "field", "value")
+	deletedCount := m.Del("key", "diff")
+	assert.ExpectEq(deletedCount, 0, t)
+}

--- a/internal/pkg/storage/storage.go
+++ b/internal/pkg/storage/storage.go
@@ -1,0 +1,20 @@
+// Package storage defines an interface for the data structure that backs the GoDB storage engine.
+package storage
+
+// The ObjectStore interface defines the supported methods on the GoDB storage engine.
+type ObjectStore interface {
+
+	// The Set method accepts a key and field to address the storage engine and a value to set at this location.
+	// Set returns the count of inserted or updated records, which will always be 1.
+	Set(key string, field string, value string) int
+
+	// The Get method accepts a key and field to address the storage engine. Get returns the value at this location, if
+	// it exists. If it does not exist, Get returns an empty string and a false boolean value.
+	Get(key string, field string) (string, bool)
+
+	// The Del method accepts a key and field to address the storage engine. Del attempts to erase the field-value pair
+	// from the given key. If the address is valid, the item is removed, and the count of deleted items (1) is returned.
+	// If the address is not valid, nothing is deleted, and the method returns a count of 0.
+	Del(key string, field string) int
+
+}


### PR DESCRIPTION
Defined ObjectStore interface and implemented it with the Map object. The Map object is backed by a simple Golang map[string]map[string]string. Tested Map object. Closes #1 